### PR TITLE
docs(readme): fix typos in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,10 +272,10 @@ This method is recommended for developers who want to:
   Hint: Be aware that this can have beta-features and more likely got bugs than the stable release
 
 >**Open the WebUI to test (Default: http://localhost:5173)**
->   - Beginngers: 
+>   - Beginners:
 >     - Try to use a sophisticated Provider/Model like Anthropic with Claude Sonnet 3.x Models to get best results
->     - Explanation: The System Prompt currently implemented in bolt.diy cant cover the best performance for all providers and models out there. So it works better with some models, then other, even if the models itself are perfect for >programming
->     - Future: Planned is a Plugin/Extentions-Library so there can be different System Prompts for different Models, which will help to get better results
+>     - Explanation: The System Prompt currently implemented in bolt.diy can't cover the best performance for all providers and models out there. So it works better with some models, then other, even if the models itself are perfect for >programming
+>     - Future: Planned is a Plugin/Extensions-Library so there can be different System Prompts for different Models, which will help to get better results
 
 #### Staying Updated
 


### PR DESCRIPTION
## Summary
- correct typos in README setup instructions

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684221c600bc83238c0e57d0e5754ee6