### PR TITLE
chore(docker): add setup for karma service and Neo4j

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -120,3 +120,12 @@ VITE_GITHUB_TOKEN_TYPE=classic
 # DEFAULT_NUM_CTX=12288 # Consumes 26GB of VRAM
 # DEFAULT_NUM_CTX=6144 # Consumes 24GB of VRAM
 DEFAULT_NUM_CTX=
+
+# Karma Service URL
+KARMA_API_URL=http://karma-service:5000
+
+# Neo4j database password
+NEO4J_PASSWORD=
+
+# Enable verbose logging
+DEBUG=true

--- a/docker-compose.services.yaml
+++ b/docker-compose.services.yaml
@@ -1,0 +1,65 @@
+version: '3.8'
+
+services:
+  # Node.js API mit Multi-Agent-Workflow
+  karma-service:
+    image: node:20
+    container_name: karma-service
+    working_dir: /usr/src/app
+    volumes:
+      - ./karma-service:/usr/src/app
+    ports:
+      - "5000:5000"
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+    networks:
+      - internal
+
+  # Graphdatenbank
+  neo4j:
+    image: neo4j:5
+    container_name: neo4j
+    ports:
+      - "7474:7474"
+      - "7687:7687"
+    environment:
+      - NEO4J_AUTH=neo4j/${NEO4J_PASSWORD}
+    volumes:
+      - neo4j-data:/data
+    networks:
+      - internal
+
+  # Next.js UI (Platzhalter)
+  frontend:
+    image: node:20
+    container_name: frontend
+    working_dir: /usr/src/app
+    volumes:
+      - ./frontend:/usr/src/app
+    ports:
+      - "3000:3000"
+    environment:
+      - KARMA_API_URL=${KARMA_API_URL}
+    networks:
+      - internal
+
+  # Projekt-API (z.\xA0B. f\xC3\xBCr LandRad, SatoshiFlow)
+  backend:
+    image: node:20
+    container_name: backend
+    working_dir: /usr/src/app
+    volumes:
+      - ./backend:/usr/src/app
+    ports:
+      - "4000:4000"
+    environment:
+      - KARMA_API_URL=${KARMA_API_URL}
+    networks:
+      - internal
+
+networks:
+  internal:
+    driver: bridge
+
+volumes:
+  neo4j-data:


### PR DESCRIPTION
## Summary
- add docker-compose file with karma service, Neo4j, frontend and backend
- extend `.env.example` with karma URL, Neo4j password and debug option

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a45735588323adc9882de92a0771